### PR TITLE
akamai-cps-orchestrator v2.1.0: Support Contract ID Default on the certificate store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.0
+## Features
+- Add a default Contract ID to the certificate store type, allowing for a per-store default with an override provided via the entry parameter. The existing Contract ID entry parameter has been renamed to Contract ID Override and has been made optional. This update is backwards compatible with older versions of the certificate store type.
+
+
 # 2.0.2
 ## Fixes
 - Fix an issue where the `ECC` key type is not properly handled when fetching the CSR from Akamai

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use the Akamai Certificate Provisioning System (CPS) Universal Orchestrator e
 > To set the `default` values for the Entry Parameters, you will need to re-open the Certificate Store Type configuration after saving and running [this SQL script](akamai-cps-orchestrator/jobproperties.sql). This is due to a UI limitation.
 
 > [!IMPORTANT]
-> The `Contract ID` should be set to the default contract to be used for new Enrollments. 
+> The `Contract ID` should be set to the [default contract](#contract-id-defaults) to be used for new Enrollments. 
  
 > [!IMPORTANT]
 > All address information should be filled out with default expected values, as they are required fields for **each** enrollment created and should not be entered manually unless they need to be overwritten for a specific Enrollment in Akamai.
@@ -173,6 +173,7 @@ the Keyfactor Command Portal
    | access_token | Access Token | The Akamai access_token for authentication. | Secret |  | ✅ Checked |
    | client_token | Client Token | The Akamai client_token for authentication. | Secret |  | ✅ Checked |
    | client_secret | Client Secret | The Akamai client_secret for authentication. | Secret |  | ✅ Checked |
+   | ContractId | Contract ID | The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence. | String |  | 🔲 Unchecked |
 
    The Custom Fields tab should look like this:
 
@@ -199,31 +200,11 @@ the Keyfactor Command Portal
    ![Akamai Custom Field - client_secret](docsource/images/Akamai-custom-field-client_secret-validation-options-dialog.svg)
 
 
+   ###### Contract ID
+   The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence.
 
-   ###### Access Token
-   The Akamai access_token for authentication.
-
-   ![Akamai Custom Field - access_token](docsource/images/Akamai-custom-field-access_token-dialog.png)
-   ![Akamai Custom Field - access_token](docsource/images/Akamai-custom-field-access_token-validation-options-dialog.png)
-
-
-
-   ###### Client Token
-   The Akamai client_token for authentication.
-
-   ![Akamai Custom Field - client_token](docsource/images/Akamai-custom-field-client_token-dialog.png)
-   ![Akamai Custom Field - client_token](docsource/images/Akamai-custom-field-client_token-validation-options-dialog.png)
-
-
-
-   ###### Client Secret
-   The Akamai client_secret for authentication.
-
-   ![Akamai Custom Field - client_secret](docsource/images/Akamai-custom-field-client_secret-dialog.png)
-   ![Akamai Custom Field - client_secret](docsource/images/Akamai-custom-field-client_secret-validation-options-dialog.png)
-
-
-
+   ![Akamai Custom Field - ContractId](docsource/images/Akamai-custom-field-ContractId-dialog.svg)
+   ![Akamai Custom Field - ContractId](docsource/images/Akamai-custom-field-ContractId-validation-options-dialog.svg)
 
 
    ##### Entry Parameters Tab
@@ -231,7 +212,7 @@ the Keyfactor Command Portal
    | Name | Display Name | Description | Type | Default Value | Entry has a private key | Adding an entry | Removing an entry | Reenrolling an entry |
    | ---- | ------------ | ---- | ------------- | ----------------------- | ---------------- | ----------------- | ------------------- | ----------- |
    | EnrollmentId | Enrollment ID | Enrollment ID of a certificate enrollment in Akamai. This should only be supplied for ODKG when replacing an existing certificate. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
-   | ContractId | Contract ID | The Contract ID of your account in Akamai. | String | SET-DEFAULT | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
+   | ContractId | Contract ID Override | The Contract ID of your account in Akamai. If a Contract ID is defined on the certificate store, the value of this parameter will take precedence. If a Contract ID is not defined on the certificate store, a value is required for this parameter. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
    | Sans | SANs | SANs for the new certificate. If multiple are supplied, they should be split with an ampersand character '&' | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
    | admin-addressLineOne | Admin - Address Line 1 | Required field for Administrator contact. | String | SET-DEFAULT | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | ✅ Checked |
    | admin-addressLineTwo | Admin - Address Line 2 | Optional field for Administrator contact. | String |  | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked | 🔲 Unchecked |
@@ -277,8 +258,8 @@ the Keyfactor Command Portal
    ![Akamai Entry Parameter - EnrollmentId](docsource/images/Akamai-entry-parameters-store-type-dialog-EnrollmentId-validation-options.svg)
 
 
-   ##### Contract ID
-   The Contract ID of your account in Akamai.
+   ##### Contract ID Override
+   The Contract ID of your account in Akamai. If a Contract ID is defined on the certificate store, the value of this parameter will take precedence. If a Contract ID is not defined on the certificate store, a value is required for this parameter.
 
    ![Akamai Entry Parameter - ContractId](docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId.svg)
    ![Akamai Entry Parameter - ContractId](docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId-validation-options.svg)
@@ -522,260 +503,6 @@ the Keyfactor Command Portal
    ![Akamai Entry Parameter - deployment-network](docsource/images/Akamai-entry-parameters-store-type-dialog-deployment-network-validation-options.svg)
 
 
-
-   ##### Enrollment ID
-   Enrollment ID of a certificate enrollment in Akamai. This should only be supplied for ODKG when replacing an existing certificate.
-
-   ![Akamai Entry Parameter - EnrollmentId](docsource/images/Akamai-entry-parameters-store-type-dialog-EnrollmentId.png)
-   ![Akamai Entry Parameter - EnrollmentId](docsource/images/Akamai-entry-parameters-store-type-dialog-EnrollmentId-validation-options.png)
-
-
-   ##### Contract ID
-   The Contract ID of your account in Akamai.
-
-   ![Akamai Entry Parameter - ContractId](docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId.png)
-   ![Akamai Entry Parameter - ContractId](docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId-validation-options.png)
-
-
-   ##### SANs
-   SANs for the new certificate. If multiple are supplied, they should be split with an ampersand character '&'
-
-   ![Akamai Entry Parameter - Sans](docsource/images/Akamai-entry-parameters-store-type-dialog-Sans.png)
-   ![Akamai Entry Parameter - Sans](docsource/images/Akamai-entry-parameters-store-type-dialog-Sans-validation-options.png)
-
-
-   ##### Admin - Address Line 1
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-addressLineOne.png)
-   ![Akamai Entry Parameter - admin-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-addressLineOne-validation-options.png)
-
-
-   ##### Admin - Address Line 2
-   Optional field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-addressLineTwo.png)
-   ![Akamai Entry Parameter - admin-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-addressLineTwo-validation-options.png)
-
-
-   ##### Admin - City
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-city](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-city.png)
-   ![Akamai Entry Parameter - admin-city](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-city-validation-options.png)
-
-
-   ##### Admin - Country
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-country](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-country.png)
-   ![Akamai Entry Parameter - admin-country](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-country-validation-options.png)
-
-
-   ##### Admin - Email
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-email](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-email.png)
-   ![Akamai Entry Parameter - admin-email](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-email-validation-options.png)
-
-
-   ##### Admin - First Name
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-firstName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-firstName.png)
-   ![Akamai Entry Parameter - admin-firstName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-firstName-validation-options.png)
-
-
-   ##### Admin - Last Name
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-lastName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-lastName.png)
-   ![Akamai Entry Parameter - admin-lastName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-lastName-validation-options.png)
-
-
-   ##### Admin - Organization Name
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-organizationName.png)
-   ![Akamai Entry Parameter - admin-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-organizationName-validation-options.png)
-
-
-   ##### Admin - Phone
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-phone.png)
-   ![Akamai Entry Parameter - admin-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-phone-validation-options.png)
-
-
-   ##### Admin - Postal Code
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-postalCode.png)
-   ![Akamai Entry Parameter - admin-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-postalCode-validation-options.png)
-
-
-   ##### Admin - Region
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-region](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-region.png)
-   ![Akamai Entry Parameter - admin-region](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-region-validation-options.png)
-
-
-   ##### Admin - Title
-   Required field for Administrator contact.
-
-   ![Akamai Entry Parameter - admin-title](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-title.png)
-   ![Akamai Entry Parameter - admin-title](docsource/images/Akamai-entry-parameters-store-type-dialog-admin-title-validation-options.png)
-
-
-   ##### Org - Address Line 1
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-org-addressLineOne.png)
-   ![Akamai Entry Parameter - org-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-org-addressLineOne-validation-options.png)
-
-
-   ##### Org - Address Line 2
-   Optional field for Organization contact.
-
-   ![Akamai Entry Parameter - org-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-org-addressLineTwo.png)
-   ![Akamai Entry Parameter - org-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-org-addressLineTwo-validation-options.png)
-
-
-   ##### Org - City
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-city](docsource/images/Akamai-entry-parameters-store-type-dialog-org-city.png)
-   ![Akamai Entry Parameter - org-city](docsource/images/Akamai-entry-parameters-store-type-dialog-org-city-validation-options.png)
-
-
-   ##### Org - Country
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-country](docsource/images/Akamai-entry-parameters-store-type-dialog-org-country.png)
-   ![Akamai Entry Parameter - org-country](docsource/images/Akamai-entry-parameters-store-type-dialog-org-country-validation-options.png)
-
-
-   ##### Org - Organization Name
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-org-organizationName.png)
-   ![Akamai Entry Parameter - org-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-org-organizationName-validation-options.png)
-
-
-   ##### Org - Phone
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-org-phone.png)
-   ![Akamai Entry Parameter - org-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-org-phone-validation-options.png)
-
-
-   ##### Org - Postal Code
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-org-postalCode.png)
-   ![Akamai Entry Parameter - org-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-org-postalCode-validation-options.png)
-
-
-   ##### Org - Region
-   Required field for Organization contact.
-
-   ![Akamai Entry Parameter - org-region](docsource/images/Akamai-entry-parameters-store-type-dialog-org-region.png)
-   ![Akamai Entry Parameter - org-region](docsource/images/Akamai-entry-parameters-store-type-dialog-org-region-validation-options.png)
-
-
-   ##### Tech - Address Line 1
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-addressLineOne.png)
-   ![Akamai Entry Parameter - tech-addressLineOne](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-addressLineOne-validation-options.png)
-
-
-   ##### Tech - Address Line 2
-   Optional field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-addressLineTwo.png)
-   ![Akamai Entry Parameter - tech-addressLineTwo](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-addressLineTwo-validation-options.png)
-
-
-   ##### Tech - City
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-city](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-city.png)
-   ![Akamai Entry Parameter - tech-city](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-city-validation-options.png)
-
-
-   ##### Tech - Country
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-country](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-country.png)
-   ![Akamai Entry Parameter - tech-country](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-country-validation-options.png)
-
-
-   ##### Tech - Email
-   Required field for Akamai Tech contact. Must be an akamai.com email address.
-
-   ![Akamai Entry Parameter - tech-email](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-email.png)
-   ![Akamai Entry Parameter - tech-email](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-email-validation-options.png)
-
-
-   ##### Tech - First Name
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-firstName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-firstName.png)
-   ![Akamai Entry Parameter - tech-firstName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-firstName-validation-options.png)
-
-
-   ##### Tech - Last Name
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-lastName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-lastName.png)
-   ![Akamai Entry Parameter - tech-lastName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-lastName-validation-options.png)
-
-
-   ##### Tech - Organization Name
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-organizationName.png)
-   ![Akamai Entry Parameter - tech-organizationName](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-organizationName-validation-options.png)
-
-
-   ##### Tech - Phone
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-phone.png)
-   ![Akamai Entry Parameter - tech-phone](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-phone-validation-options.png)
-
-
-   ##### Tech - Postal Code
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-postalCode.png)
-   ![Akamai Entry Parameter - tech-postalCode](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-postalCode-validation-options.png)
-
-
-   ##### Tech - Region
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-region](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-region.png)
-   ![Akamai Entry Parameter - tech-region](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-region-validation-options.png)
-
-
-   ##### Tech - Title
-   Required field for Akamai Tech contact.
-
-   ![Akamai Entry Parameter - tech-title](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-title.png)
-   ![Akamai Entry Parameter - tech-title](docsource/images/Akamai-entry-parameters-store-type-dialog-tech-title-validation-options.png)
-
-
-   ##### Deployment Network
-   Required field for Deployment Network.
-
-   ![Akamai Entry Parameter - deployment-network](docsource/images/Akamai-entry-parameters-store-type-dialog-deployment-network.png)
-   ![Akamai Entry Parameter - deployment-network](docsource/images/Akamai-entry-parameters-store-type-dialog-deployment-network-validation-options.png)
-
-
-
    </details>
 
 ## Installation
@@ -787,7 +514,7 @@ the Keyfactor Command Portal
    | Universal Orchestrator Version | Latest .NET version installed on the Universal Orchestrator server | `rollForward` condition in `Orchestrator.runtimeconfig.json` | `akamai-cps-orchestrator` .NET version to download |
    | --------- | ----------- | ----------- | ----------- |
    | Between `11.0.0` and `11.5.1` (inclusive) | `net8.0` | `LatestMajor` | `net8.0` |
-   | `11.6` _and_ newer | `net8.0` | | `net8.0` | 
+   | `11.6` _and_ newer | `net8.0` | | `net8.0` |
 
     Unzip the archive containing extension assemblies to a known location.
 
@@ -843,6 +570,7 @@ the Keyfactor Command Portal
    | access_token | The Akamai access_token for authentication. |
    | client_token | The Akamai client_token for authentication. |
    | client_secret | The Akamai client_secret for authentication. |
+   | ContractId | The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence. |
 
 </details>
 
@@ -869,6 +597,7 @@ the Keyfactor Command Portal
    | Properties.access_token | The Akamai access_token for authentication. |
    | Properties.client_token | The Akamai client_token for authentication. |
    | Properties.client_secret | The Akamai client_secret for authentication. |
+   | Properties.ContractId | The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence. |
 
 3. **Import the CSV file to create the certificate stores**
 
@@ -949,6 +678,16 @@ Currently, only the leaf certificate is returned from Keyfactor Command after en
 - Searching the trust store of the system running the orchestrator for matching intermediate and root certificates (both must be found in order to build the chain)
 
 If the trust chain cannot be built using either of these methods, the orchestrator will still complete the enrollment, but a warning message will be returned indicating that the trust chain could not be built. Please ensure that the intermediate and root certificates are part of your system's trust store or have publicly available AIA information to allow the orchestrator to build the trust chain successfully.
+
+#### Contract ID Defaults
+
+In order to create a new enrollment in Akamai CPS, Akamai requires that a [Contract ID](https://techdocs.akamai.com/cps/reference/get-started) be provided. You can find your Contract ID in the Akamai Control Center dashboard. As of v2.1.0 of the Akamai CPS Orchestrator integration, the Contract ID can be specified on the certificate store and on the re-enrollment (ODKG) entry parameter. The certificate store's **Contract ID** will be the default Contract ID for all re-enrollment jobs for the certificate store. The Contract ID re-enrollment entry parameter (**Contract ID Override**) will allow you to override the certificate store Contract ID value, in case you need to specify a different Contract ID for a specific re-enrollment job.
+
+If an Enrollment ID is not provided on the re-enrollment job, a Contract ID will be required to create a new Akamai enrollment. If a Contract ID is not provided on the certificate store or on the re-enrollment entry parameter, the job will fail with the following message: "A Contract ID is required when creating an Akamai enrollment. Please provide a Contract ID on the Reenrollment job or in the certificate store in Keyfactor Command.".
+
+> [!NOTE]
+>
+> If you created your certificate store prior to v2.1.0 of the integration, you can still run >= v2.1.0 as it is backwards compatible. Your entry parameter will show as **Contract ID** instead of **Contract ID Override**. We do recommend you try to update your certificate store type definition when possible, and we've provided a [SQL script](scripts/migrations/v2.1.0.sql) to help automate this migration.
 
 
 ## Use Cases

--- a/akamai-cps-orchestrator.Tests/Builders/AkamaiCertStorePropertiesBuilder.cs
+++ b/akamai-cps-orchestrator.Tests/Builders/AkamaiCertStorePropertiesBuilder.cs
@@ -1,0 +1,46 @@
+using Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Models;
+
+namespace akamai_cps_orchestrator.Tests.Builders;
+
+public class AkamaiCertStorePropertiesBuilder
+{
+    private string? _accessToken = "foo";
+    private string? _clientToken = "bar";
+    private string? _clientSecret = "baz";
+    private string? _contractId = null;
+
+    public AkamaiCertStorePropertiesBuilder WithAccessToken(string? accessToken)
+    {
+        _accessToken = accessToken;
+        return this;
+    }
+
+    public AkamaiCertStorePropertiesBuilder WithClientToken(string? clientToken)
+    {
+        _clientToken = clientToken;
+        return this;
+    }
+
+    public AkamaiCertStorePropertiesBuilder WithClientSecret(string? clientSecret)
+    {
+        _clientSecret = clientSecret;
+        return this;
+    }
+
+    public AkamaiCertStorePropertiesBuilder WithContractId(string? contractId)
+    {
+        _contractId = contractId;
+        return this;
+    }
+
+    public AkamaiCertStoreProperties Build()
+    {
+        return new AkamaiCertStoreProperties()
+        {
+            AccessToken = _accessToken,
+            ClientToken = _clientToken,
+            ClientSecret = _clientSecret,
+            ContractId = _contractId,
+        };
+    }
+}

--- a/akamai-cps-orchestrator.Tests/Builders/AkamaiCertStorePropertiesBuilder.cs
+++ b/akamai-cps-orchestrator.Tests/Builders/AkamaiCertStorePropertiesBuilder.cs
@@ -1,3 +1,17 @@
+// Copyright 2026 Keyfactor
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Models;
 
 namespace akamai_cps_orchestrator.Tests.Builders;

--- a/akamai-cps-orchestrator.Tests/Builders/ReenrollmentJobPropertiesBuilder.cs
+++ b/akamai-cps-orchestrator.Tests/Builders/ReenrollmentJobPropertiesBuilder.cs
@@ -1,3 +1,17 @@
+// Copyright 2026 Keyfactor
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace akamai_cps_orchestrator.Tests.Builders;
 
 public class ReenrollmentJobPropertiesBuilder

--- a/akamai-cps-orchestrator.Tests/Builders/ReenrollmentJobPropertiesBuilder.cs
+++ b/akamai-cps-orchestrator.Tests/Builders/ReenrollmentJobPropertiesBuilder.cs
@@ -1,0 +1,75 @@
+namespace akamai_cps_orchestrator.Tests.Builders;
+
+public class ReenrollmentJobPropertiesBuilder
+{
+    private readonly Dictionary<string, object> _props = new()
+    {
+        ["subjectText"] = "CN=test.example.com,O=TestOrg,OU=TestOU,L=TestCity,ST=TestState,C=US",
+        ["keyType"] = "RSA",
+        ["ContractId"] = "contract-123",
+        ["Sans"] = "test.example.com&www.test.example.com",
+        // admin contact
+        ["admin-addressLineOne"] = "123 Main St",
+        ["admin-addressLineTwo"] = null,
+        ["admin-city"] = "TestCity",
+        ["admin-country"] = "US",
+        ["admin-email"] = "admin@test.com",
+        ["admin-firstName"] = "Admin",
+        ["admin-lastName"] = "User",
+        ["admin-organizationName"] = "TestOrg",
+        ["admin-phone"] = "555-0100",
+        ["admin-postalCode"] = "12345",
+        ["admin-region"] = "TestState",
+        ["admin-title"] = "Admin",
+        // org contact
+        ["org-addressLineOne"] = "123 Main St",
+        ["org-addressLineTwo"] = null,
+        ["org-city"] = "TestCity",
+        ["org-country"] = "US",
+        ["org-organizationName"] = "TestOrg",
+        ["org-phone"] = "555-0100",
+        ["org-postalCode"] = "12345",
+        ["org-region"] = "TestState",
+        // tech contact
+        ["tech-addressLineOne"] = "123 Main St",
+        ["tech-addressLineTwo"] = null,
+        ["tech-city"] = "TestCity",
+        ["tech-country"] = "US",
+        ["tech-email"] = "tech@test.com",
+        ["tech-firstName"] = "Tech",
+        ["tech-lastName"] = "User",
+        ["tech-organizationName"] = "TestOrg",
+        ["tech-phone"] = "555-0100",
+        ["tech-postalCode"] = "12345",
+        ["tech-region"] = "TestState",
+        ["tech-title"] = "Tech",
+    };
+
+    public ReenrollmentJobPropertiesBuilder WithKeyType(string? keyType)
+    {
+        _props["keyType"] = keyType;
+        return this;
+    }
+
+    // deployment-network is absent by default (backward-compat case); calling this,
+    // even with null, adds the key so callers can distinguish "absent" from "present but null".
+    public ReenrollmentJobPropertiesBuilder WithDeploymentNetwork(string? deploymentNetwork)
+    {
+        _props["deployment-network"] = deploymentNetwork;
+        return this;
+    }
+
+    public ReenrollmentJobPropertiesBuilder WithEnrollmentId(string? enrollmentId)
+    {
+        _props["EnrollmentId"] = enrollmentId;
+        return this;
+    }
+
+    public ReenrollmentJobPropertiesBuilder WithContractId(string? contractId)
+    {
+        _props["ContractId"] = contractId;
+        return this;
+    }
+
+    public Dictionary<string, object> Build() => new(_props);
+}

--- a/akamai-cps-orchestrator.Tests/Jobs/ReenrollmentTests.cs
+++ b/akamai-cps-orchestrator.Tests/Jobs/ReenrollmentTests.cs
@@ -15,6 +15,7 @@
 using System.Net;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using akamai_cps_orchestrator.Tests.Builders;
 using Keyfactor.Extensions.Utilities.HttpInterface.Exceptions;
 using Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Factories;
 using Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs;
@@ -24,6 +25,7 @@ using Keyfactor.Orchestrators.Common.Enums;
 using Keyfactor.Orchestrators.Extensions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Newtonsoft.Json;
 using Org.BouncyCastle.X509;
 using Xunit;
 using Xunit.Abstractions;
@@ -56,6 +58,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
     // Generated once per test class to avoid RSA key generation cost per test.
     private static readonly X509Certificate2 TestCert = CreateSelfSignedCert();
     private static readonly X509Certificate TestBcCert = CreateSelfSignedCertBouncyCastle(TestCert);
+    private static CertificateStore JobProperties;
 
     private readonly Mock<IAkamaiClientFactory> _mockFactory = new();
     private readonly Mock<IAkamaiClient> _mockClient = new();
@@ -122,8 +125,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
     [Fact]
     public void ProcessJob_WhenKeyTypeIsNotMappedToAkamaiValue_ReturnsFailure()
     {
-        var config = MakeReenrollmentConfig();
-        config.JobProperties["keyType"] = "foobar";
+        var config = MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithKeyType("foobar"));
 
         var result = GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
 
@@ -135,12 +137,36 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
 
     #region Existing Enrollments
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ProcessJob_WhenContractIdIsNullOnStoreAndProperties_DoesNotErrorWhenUpdatingEnrollment(string? contractId)
+    {
+        SetupExistingEnrollmentPath("42", "200", MakeExistingEnrollment("42"));
+        
+        // If enrollment ID is not null, then it will be treated as an update – no contract ID is required in that case.
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId("42")
+            .WithContractId(contractId);
+
+        var storeProperties = new AkamaiCertStorePropertiesBuilder()
+            .WithContractId(contractId)
+            .Build();
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder, storeProperties);
+
+        var result = GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        Assert.Equal(OrchestratorJobStatusJobResult.Success, result.Result);
+    }
+    
     [Fact]
     public void ProcessJob_WhenEnrollmentIdPresent_GetsExistingEnrollment()
     {
         SetupExistingEnrollmentPath("42", "200", MakeExistingEnrollment("42"));
 
-        GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         _mockClient.Verify(c => c.GetEnrollment("42"), Times.Once);
     }
@@ -152,7 +178,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
             .Setup(c => c.GetEnrollment(It.IsAny<string>()))
             .Throws(new Exception("Enrollment not found"));
 
-        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
     }
@@ -168,7 +194,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
             .Returns(MakeCreatedEnrollment(enrollmentId: "42", changeId: "9002"));
         SetupClientForHappyPath("42", "9002");
 
-        GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         _mockClient.Verify(c => c.DeletePendingChange("42", "9001"), Times.Once);
         _mockClient.Verify(c => c.UpdateEnrollment("42", It.IsAny<Enrollment>()), Times.Exactly(2));
@@ -186,7 +212,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
             .Setup(c => c.DeletePendingChange("42", "9001"))
             .Throws(new Exception("Delete failed"));
 
-        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
     }
@@ -199,7 +225,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
             .Setup(c => c.UpdateEnrollment("42", It.IsAny<Enrollment>()))
             .Throws(new Exception("Unexpected update error"));
 
-        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
     }
@@ -208,6 +234,33 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
 
     #region New Enrollments
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ProcessJob_WhenContractIdIsNullOnStoreAndProperties_ErrorsWhenCreatingEnrollment(string? contractId)
+    {
+        SetupNewEnrollmentPath("99", "100");
+        
+        // The integration will create a new enrollment when enrollment ID is null
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId(null)
+            .WithContractId(contractId);
+
+        var storeProperties = new AkamaiCertStorePropertiesBuilder()
+            .WithContractId(contractId)
+            .Build();
+
+        var expectedError = "A Contract ID is required when creating an Akamai enrollment";
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder, storeProperties);
+
+        var result = GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
+        Assert.Contains(expectedError, result.FailureMessage);
+    }
+    
     [Fact]
     public void ProcessJob_WhenNoEnrollmentId_CreatesNewEnrollment()
     {
@@ -241,6 +294,90 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
         var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(), _mockReenrollmentCSR.Object);
 
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
+    }
+    
+    #endregion
+    
+    #region ContractId Resolution
+    
+    [Fact]
+    public void ProcessJob_WhenContractIdIsNullOnStoreButDefinedInProperties_UsesPropertyValue()
+    {
+        var contractId = "contract-id";
+        
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId(null)
+            .WithContractId(contractId);
+
+        var storeProperties = new AkamaiCertStorePropertiesBuilder()
+            .WithContractId(null)
+            .Build();
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder, storeProperties);
+
+        GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        _mockClient.Verify(x => x.CreateEnrollment(It.IsAny<Enrollment>(), contractId), Times.Once);
+    }
+    
+    [Fact]
+    public void ProcessJob_WhenContractIdIsDefinedOnStoreButIsNullInProperties_UsesStoreValue()
+    {
+        var contractId = "contract-id";
+        
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId(null)
+            .WithContractId(null);
+
+        var storeProperties = new AkamaiCertStorePropertiesBuilder()
+            .WithContractId(contractId)
+            .Build();
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder, storeProperties);
+
+        GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        _mockClient.Verify(x => x.CreateEnrollment(It.IsAny<Enrollment>(), contractId), Times.Once);
+    }
+    
+    [Fact]
+    public void ProcessJob_WhenContractIdIsDefinedOnStoreAndProperties_UsesPropertyValue()
+    {
+        var contractId = "contract-id";
+        
+        // The value in the job properties should take precedence over the value in the store properties.
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId(null)
+            .WithContractId(contractId);
+
+        var storeProperties = new AkamaiCertStorePropertiesBuilder()
+            .WithContractId("do-not-use")
+            .Build();
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder, storeProperties);
+
+        GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        _mockClient.Verify(x => x.CreateEnrollment(It.IsAny<Enrollment>(), contractId), Times.Once);
+    }
+    
+    [Fact]
+    public void ProcessJob_WhenCertStorePropertiesIsMissingContractIdInString_StillUsesJobPropertyValue()
+    {
+        var contractId = "contract-id";
+        
+        var propertiesBuilder = new ReenrollmentJobPropertiesBuilder()
+            .WithEnrollmentId(null)
+            .WithContractId(contractId);
+        
+        var config = MakeReenrollmentConfig(propertiesBuilder);
+        
+        // Construct an empty object to verify that if the certificate store properties are missing the contract ID, the job property value is still used.
+        config.CertificateStoreDetails.Properties = "{}";
+
+        GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
+        
+        _mockClient.Verify(x => x.CreateEnrollment(It.IsAny<Enrollment>(), contractId), Times.Once);
     }
     
     #endregion
@@ -476,7 +613,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
     {
         SetupExistingEnrollmentPath("42", "200", MakeExistingEnrollment("42"));
 
-        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(enrollmentId: "42"), _mockReenrollmentCSR.Object);
+        var result = GetReenrollmentClass().ProcessJob(MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42")), _mockReenrollmentCSR.Object);
 
         Assert.Equal(OrchestratorJobStatusJobResult.Success, result.Result);
     }
@@ -531,7 +668,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
         existing.networkConfiguration.secureNetwork = "standard-tls";
         Enrollment? captured = null;
         SetupExistingEnrollmentPath("42", "200", existing, capture: e => captured = e);
-        var config = MakeReenrollmentConfig(enrollmentId: "42");
+        var config = MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42"));
         config.JobProperties["deployment-network"] = "Enhanced TLS";
         
         _mockCertificateChainService
@@ -618,7 +755,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
         existing.networkConfiguration.secureNetwork = existingNetwork;
         Enrollment? captured = null;
         SetupExistingEnrollmentPath("42", "200", existing, capture: e => captured = e);
-        var config = MakeReenrollmentConfig(enrollmentId: "42");
+        var config = MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42"));
         config.JobProperties["deployment-network"] = reenrollmentNetwork;
 
         var result = GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
@@ -640,7 +777,7 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
         existing.networkConfiguration.secureNetwork = existingNetwork;
         Enrollment? captured = null;
         SetupExistingEnrollmentPath("42", "200", existing, capture: e => captured = e);
-        var config = MakeReenrollmentConfig(enrollmentId: "42");
+        var config = MakeReenrollmentConfig(new ReenrollmentJobPropertiesBuilder().WithEnrollmentId("42"));
         config.JobProperties["deployment-network"] = reenrollmentNetwork;
 
         var result = GetReenrollmentClass().ProcessJob(config, _mockReenrollmentCSR.Object);
@@ -694,63 +831,24 @@ public class ReenrollmentTests : BaseJobTest<ReenrollmentTests>
             .Returns(_fakeChange);
     }
 
-    private static ReenrollmentJobConfiguration MakeReenrollmentConfig(string enrollmentId = null)
+    private static ReenrollmentJobConfiguration MakeReenrollmentConfig(
+        ReenrollmentJobPropertiesBuilder? jobProperties = null, AkamaiCertStoreProperties? properties = null)
     {
-        var props = new Dictionary<string, object>
+        var props = (jobProperties ?? new ReenrollmentJobPropertiesBuilder()).Build();
+
+        properties ??= new AkamaiCertStorePropertiesBuilder()
+            .Build();
+
+        JobProperties = new CertificateStore
         {
-            ["subjectText"] = "CN=test.example.com,O=TestOrg,OU=TestOU,L=TestCity,ST=TestState,C=US",
-            ["keyType"] = "RSA",
-            ["ContractId"] = "contract-123",
-            ["Sans"] = "test.example.com&www.test.example.com",
-            // admin contact
-            ["admin-addressLineOne"] = "123 Main St",
-            ["admin-addressLineTwo"] = null,
-            ["admin-city"] = "TestCity",
-            ["admin-country"] = "US",
-            ["admin-email"] = "admin@test.com",
-            ["admin-firstName"] = "Admin",
-            ["admin-lastName"] = "User",
-            ["admin-organizationName"] = "TestOrg",
-            ["admin-phone"] = "555-0100",
-            ["admin-postalCode"] = "12345",
-            ["admin-region"] = "TestState",
-            ["admin-title"] = "Admin",
-            // org contact
-            ["org-addressLineOne"] = "123 Main St",
-            ["org-addressLineTwo"] = null,
-            ["org-city"] = "TestCity",
-            ["org-country"] = "US",
-            ["org-organizationName"] = "TestOrg",
-            ["org-phone"] = "555-0100",
-            ["org-postalCode"] = "12345",
-            ["org-region"] = "TestState",
-            // tech contact
-            ["tech-addressLineOne"] = "123 Main St",
-            ["tech-addressLineTwo"] = null,
-            ["tech-city"] = "TestCity",
-            ["tech-country"] = "US",
-            ["tech-email"] = "tech@test.com",
-            ["tech-firstName"] = "Tech",
-            ["tech-lastName"] = "User",
-            ["tech-organizationName"] = "TestOrg",
-            ["tech-phone"] = "555-0100",
-            ["tech-postalCode"] = "12345",
-            ["tech-region"] = "TestState",
-            ["tech-title"] = "Tech",
+            Properties = JsonConvert.SerializeObject(properties),
+            ClientMachine = "test.akamai.example.com",
+            StorePath = "Production",
         };
-
-        if (enrollmentId != null)
-            props["EnrollmentId"] = enrollmentId;
-
         return new ReenrollmentJobConfiguration
         {
             JobHistoryId = 1,
-            CertificateStoreDetails = new CertificateStore
-            {
-                Properties = "{}",
-                ClientMachine = "test.akamai.example.com",
-                StorePath = "Production",
-            },
+            CertificateStoreDetails = JobProperties,
             JobProperties = props,
         };
     }

--- a/akamai-cps-orchestrator/Jobs/Reenrollment.cs
+++ b/akamai-cps-orchestrator/Jobs/Reenrollment.cs
@@ -61,6 +61,7 @@ namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs
         {
             JobHistoryId = jobConfig.JobHistoryId;
             var allJobProps = jobConfig.JobProperties;
+            var certStore = jobConfig.CertificateStoreDetails;
 
             // Create the Akamai API client.
             IAkamaiClient client;
@@ -79,7 +80,7 @@ namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs
             string contractId, keyType;
             try
             {
-                (reenrollment, contractId, keyType) = BuildEnrollmentRequest(allJobProps);
+                (reenrollment, contractId, keyType) = BuildEnrollmentRequest(jobConfig);
             }
             catch (Exception e)
             {
@@ -226,14 +227,19 @@ namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs
         /// Parses the Enrollment object, contract ID, and key type from job properties.
         /// Throws <see cref="ArgumentException"/> if any required field is missing.
         /// </summary>
-        private (Enrollment enrollment, string contractId, string keyType) BuildEnrollmentRequest(
-            Dictionary<string, object> jobProps)
+        private (Enrollment enrollment, string? contractId, string keyType) BuildEnrollmentRequest(
+            ReenrollmentJobConfiguration jobConfig)
         {
+            _logger.MethodEntry();
+
+            var certStoreProperties = jobConfig.CertificateStoreDetails.Properties;
+            var jobProps = jobConfig.JobProperties;
+            
             _logger.LogTrace("Parsing enrollment request from job properties.");
 
             string subject = GetRequiredValue(jobProps, "subjectText");
             string commandKeyType = GetRequiredValue(jobProps, "keyType");
-            string contractId = GetRequiredValue(jobProps, "ContractId");
+            string contractId = GetContractId(certStoreProperties, jobProps);
             string sans = GetRequiredValue(jobProps, "Sans");
 
             string keyType = MapCommandKeyTypeToAkamaiKeyType(commandKeyType);
@@ -276,6 +282,30 @@ namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs
             return (enrollment, contractId, keyType);
         }
 
+        private string? GetContractId(string certStoreProperties, Dictionary<string, object> jobConfigProperties)
+        {
+            _logger.LogTrace($"Resolving contract ID from store properties and job properties");
+
+            var isFound = jobConfigProperties.TryGetValue("ContractId", out object? contractIdOverride);
+
+            _logger.LogTrace($"ContractId found in job properties? {isFound}, ContractId value: {contractIdOverride}");
+
+            if (contractIdOverride != null)
+            {
+                var value = contractIdOverride?.ToString();
+                _logger.LogDebug($"Using ContractId found in job properties: {value}");
+                return value;
+            }
+            
+            _logger.LogTrace("Fetching ContractId from store properties");
+
+            var properties = JsonConvert.DeserializeObject<AkamaiCertStoreProperties>(certStoreProperties);
+            
+            _logger.LogDebug($"ContractId found in store properties: {properties.ContractId}");
+
+            return properties.ContractId;
+        }
+
         private string MapCommandKeyTypeToAkamaiKeyType(string commandKeyType)
         {
             _logger.MethodEntry();
@@ -315,9 +345,15 @@ namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Jobs
         /// Throws if the enrollment already exists (HTTP 409) or on any other API error.
         /// </summary>
         private (CreatedEnrollment createdEnrollment, string enrollmentId) CreateNewEnrollment(
-            IAkamaiClient client, Enrollment reenrollment, string contractId)
+            IAkamaiClient client, Enrollment reenrollment, string? contractId)
         {
             _logger.LogDebug("No existing enrollment found. Creating new enrollment for CN={cn}.", reenrollment.csr.cn);
+
+            if (string.IsNullOrWhiteSpace(contractId))
+            {
+                _logger.LogError("The resolved contract ID is null or empty. A contract ID is required to create a new Akamai enrollment.");
+                throw new InvalidOperationException($"A Contract ID is required when creating an Akamai enrollment. Please provide a Contract ID on the Reenrollment job or in the certificate store in Keyfactor Command.");
+            }
 
             CreatedEnrollment createdEnrollment;
             try

--- a/akamai-cps-orchestrator/Models/AkamaiCertStoreProperties.cs
+++ b/akamai-cps-orchestrator/Models/AkamaiCertStoreProperties.cs
@@ -1,3 +1,17 @@
+// Copyright 2026 Keyfactor
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Newtonsoft.Json;
 
 namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Models;

--- a/akamai-cps-orchestrator/Models/AkamaiCertStoreProperties.cs
+++ b/akamai-cps-orchestrator/Models/AkamaiCertStoreProperties.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace Keyfactor.Orchestrator.Extensions.AkamaiCpsOrchestrator.Models;
+
+public class AkamaiCertStoreProperties
+{
+    [JsonProperty("access_token")]
+    public string AccessToken { get; set; }
+    
+    [JsonProperty("client_token")]
+    public string ClientToken { get; set; }
+    
+    [JsonProperty("client_secret")]
+    public string ClientSecret { get; set; }
+    
+    [JsonProperty("ContractId")]
+    public string? ContractId { get; set; }
+}

--- a/docsource/akamai.md
+++ b/docsource/akamai.md
@@ -7,7 +7,7 @@
 > To set the `default` values for the Entry Parameters, you will need to re-open the Certificate Store Type configuration after saving and running [this SQL script](akamai-cps-orchestrator/jobproperties.sql). This is due to a UI limitation.
 
 > [!IMPORTANT]
-> The `Contract ID` should be set to the default contract to be used for new Enrollments. 
+> The `Contract ID` should be set to the [default contract](#contract-id-defaults) to be used for new Enrollments. 
  
 > [!IMPORTANT]
 > All address information should be filled out with default expected values, as they are required fields for **each** enrollment created and should not be entered manually unless they need to be overwritten for a specific Enrollment in Akamai.
@@ -69,3 +69,12 @@ Currently, only the leaf certificate is returned from Keyfactor Command after en
 
 If the trust chain cannot be built using either of these methods, the orchestrator will still complete the enrollment, but a warning message will be returned indicating that the trust chain could not be built. Please ensure that the intermediate and root certificates are part of your system's trust store or have publicly available AIA information to allow the orchestrator to build the trust chain successfully.
 
+### Contract ID Defaults
+
+In order to create a new enrollment in Akamai CPS, Akamai requires that a [Contract ID](https://techdocs.akamai.com/cps/reference/get-started) be provided. You can find your Contract ID in the Akamai Control Center dashboard. As of v2.1.0 of the Akamai CPS Orchestrator integration, the Contract ID can be specified on the certificate store and on the re-enrollment (ODKG) entry parameter. The certificate store's **Contract ID** will be the default Contract ID for all re-enrollment jobs for the certificate store. The Contract ID re-enrollment entry parameter (**Contract ID Override**) will allow you to override the certificate store Contract ID value, in case you need to specify a different Contract ID for a specific re-enrollment job.
+
+If an Enrollment ID is not provided on the re-enrollment job, a Contract ID will be required to create a new Akamai enrollment. If a Contract ID is not provided on the certificate store or on the re-enrollment entry parameter, the job will fail with the following message: "A Contract ID is required when creating an Akamai enrollment. Please provide a Contract ID on the Reenrollment job or in the certificate store in Keyfactor Command.".
+
+> [!NOTE]
+>
+> If you created your certificate store prior to v2.1.0 of the integration, you can still run >= v2.1.0 as it is backwards compatible. Your entry parameter will show as **Contract ID** instead of **Contract ID Override**. We do recommend you try to update your certificate store type definition when possible, and we've provided a [SQL script](scripts/migrations/v2.1.0.sql) to help automate this migration.

--- a/docsource/images/Akamai-custom-field-ContractId-dialog.svg
+++ b/docsource/images/Akamai-custom-field-ContractId-dialog.svg
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<svg width="700" height="540" viewBox="0 0 700 540" xmlns="http://www.w3.org/2000/svg">
+<svg width="700" height="477" viewBox="0 0 700 477" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
         text { font-family: 'Segoe UI', Arial, sans-serif; }
@@ -11,10 +11,10 @@
         .tab-active { font-size: 12px; fill: #111111; font-weight: 600; }
     </style>
   </defs>
-  <rect x="0" y="0" width="700" height="540" fill="#ffffff" stroke="#cccccc" stroke-width="1" />
+  <rect x="0" y="0" width="700" height="477" fill="#ffffff" stroke="#cccccc" stroke-width="1" />
   <rect x="0" y="0" width="700" height="44" fill="#f0f0f0" />
   <line x1="0" y1="44" x2="700" y2="44" stroke="#cccccc" stroke-width="1" />
-  <text x="16" y="32" class="title">Edit Entry Parameter</text>
+  <text x="16" y="32" class="title">Edit Custom Field</text>
   <text x="684" y="34" text-anchor="end" font-size="20" fill="#666666" font-family="'Segoe UI', Arial, sans-serif">×</text>
   <g>
     <rect x="0" y="44" width="700" height="36" fill="#ffffff" />
@@ -25,10 +25,10 @@
   </g>
   <text x="20" y="110" class="label">Name</text>
   <rect x="20" y="113" width="660" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
-  <text x="30" y="138" class="value">EnrollmentId</text>
+  <text x="30" y="138" class="value">ContractId</text>
   <text x="20" y="173" class="label">Display Name</text>
   <rect x="20" y="176" width="660" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
-  <text x="30" y="201" class="value">Enrollment ID</text>
+  <text x="30" y="201" class="value">Contract ID</text>
   <text x="20" y="236" class="label">Type</text>
   <rect x="20" y="239" width="660" height="36" fill="#e8e8e8" stroke="#cccccc" rx="4" />
   <text x="30" y="264" class="value">String</text>
@@ -36,17 +36,14 @@
   <text x="20" y="299" class="label">Default Value</text>
   <rect x="20" y="302" width="660" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
   <text x="30" y="327" class="value"></text>
-  <text x="20" y="362" class="label">Multiple Choice Options</text>
-  <rect x="20" y="365" width="660" height="36" fill="#e0e0e0" stroke="#cccccc" rx="4" />
-  <text x="30" y="390" class="value"></text>
-  <text x="20" y="425" class="label">Depends On</text>
-  <rect x="20" y="438" width="15" height="15" fill="#ffffff" stroke="#cccccc" rx="2" />
-  <rect x="43" y="428" width="637" height="36" fill="#e8e8e8" stroke="#cccccc" rx="4" />
-  <text x="53" y="453" class="value">Contract ID Override</text>
-  <text x="666" y="454" font-size="12" fill="#666666" font-family="'Segoe UI', Arial, sans-serif">∨</text>
-  <line x1="0" y1="480" x2="700" y2="480" stroke="#e0e0e0" stroke-width="1" />
-  <rect x="500" y="492" width="90" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
-  <text x="545" y="517" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#333333">CANCEL</text>
-  <rect x="600" y="492" width="80" height="36" fill="#222222" stroke="none" rx="4" />
-  <text x="640" y="517" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#ffffff">SAVE</text>
+  <text x="20" y="362" class="label">Depends On</text>
+  <rect x="20" y="375" width="15" height="15" fill="#ffffff" stroke="#cccccc" rx="2" />
+  <rect x="43" y="365" width="637" height="36" fill="#e8e8e8" stroke="#cccccc" rx="4" />
+  <text x="53" y="390" class="value">Access Token</text>
+  <text x="666" y="391" font-size="12" fill="#666666" font-family="'Segoe UI', Arial, sans-serif">∨</text>
+  <line x1="0" y1="417" x2="700" y2="417" stroke="#e0e0e0" stroke-width="1" />
+  <rect x="500" y="429" width="90" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
+  <text x="545" y="454" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#333333">CANCEL</text>
+  <rect x="600" y="429" width="80" height="36" fill="#222222" stroke="none" rx="4" />
+  <text x="640" y="454" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#ffffff">SAVE</text>
 </svg>

--- a/docsource/images/Akamai-custom-field-ContractId-validation-options-dialog.svg
+++ b/docsource/images/Akamai-custom-field-ContractId-validation-options-dialog.svg
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<svg width="700" height="228" viewBox="0 0 700 228" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+        text { font-family: 'Segoe UI', Arial, sans-serif; }
+        .title { font-size: 20px; font-weight: 600; fill: #222222; }
+        .section-header { font-size: 13px; font-weight: 600; fill: #333333; }
+        .label { font-size: 12px; fill: #555555; }
+        .value { font-size: 12px; fill: #222222; }
+        .tab-text { font-size: 12px; fill: #444444; }
+        .tab-active { font-size: 12px; fill: #111111; font-weight: 600; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="700" height="228" fill="#ffffff" stroke="#cccccc" stroke-width="1" />
+  <rect x="0" y="0" width="700" height="44" fill="#f0f0f0" />
+  <line x1="0" y1="44" x2="700" y2="44" stroke="#cccccc" stroke-width="1" />
+  <text x="16" y="32" class="title">Edit Custom Field</text>
+  <text x="684" y="34" text-anchor="end" font-size="20" fill="#666666" font-family="'Segoe UI', Arial, sans-serif">×</text>
+  <g>
+    <rect x="0" y="44" width="700" height="36" fill="#ffffff" />
+    <line x1="0" y1="80" x2="700" y2="80" stroke="#d0d0d0" stroke-width="1" />
+    <text x="16" y="68" class="tab-text">Basic Information</text>
+    <text x="159" y="68" class="tab-active">Validation Options</text>
+    <rect x="159" y="77" width="128" height="3" fill="#3355ee" />
+  </g>
+  <text x="20" y="112" class="label">Creating a certificate store</text>
+  <circle cx="28" cy="134" r="7" fill="#e8eeff" stroke="#3355ee" stroke-width="1.5" />
+  <circle cx="28" cy="134" r="4" fill="#3355ee" />
+  <text x="40" y="138" class="label">Optional</text>
+  <circle cx="158" cy="134" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
+  <text x="170" y="138" class="label">Required</text>
+  <circle cx="288" cy="134" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
+  <text x="300" y="138" class="label">Hidden</text>
+  <line x1="0" y1="168" x2="700" y2="168" stroke="#e0e0e0" stroke-width="1" />
+  <rect x="500" y="180" width="90" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
+  <text x="545" y="205" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#333333">CANCEL</text>
+  <rect x="600" y="180" width="80" height="36" fill="#222222" stroke="none" rx="4" />
+  <text x="640" y="205" text-anchor="middle" font-size="13" font-family="'Segoe UI', Arial, sans-serif" fill="#ffffff">SAVE</text>
+</svg>

--- a/docsource/images/Akamai-custom-fields-store-type-dialog.svg
+++ b/docsource/images/Akamai-custom-fields-store-type-dialog.svg
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<svg width="700" height="392" viewBox="0 0 700 392" xmlns="http://www.w3.org/2000/svg">
+<svg width="700" height="430" viewBox="0 0 700 430" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
         text { font-family: 'Segoe UI', Arial, sans-serif; }
@@ -11,7 +11,7 @@
         .tab-active { font-size: 12px; fill: #111111; font-weight: 600; }
     </style>
   </defs>
-  <rect x="0" y="0" width="700" height="392" fill="#ffffff" stroke="#cccccc" stroke-width="1" />
+  <rect x="0" y="0" width="700" height="430" fill="#ffffff" stroke="#cccccc" stroke-width="1" />
   <rect x="0" y="0" width="700" height="44" fill="#f0f0f0" />
   <line x1="0" y1="44" x2="700" y2="44" stroke="#cccccc" stroke-width="1" />
   <text x="16" y="32" class="title">Edit Certificate Store Type</text>
@@ -24,7 +24,7 @@
     <rect x="155" y="77" width="93" height="3" fill="#3355ee" />
     <text x="270" y="68" class="tab-text">Entry Parameters</text>
   </g>
-  <rect x="20" y="96" width="660" height="270" fill="#ffffff" stroke="#d0d0d0" rx="8" />
+  <rect x="20" y="96" width="660" height="308" fill="#ffffff" stroke="#d0d0d0" rx="8" />
   <rect x="21" y="97" width="658" height="8" fill="#f2f2f2" />
   <rect x="21" y="97" width="658" height="42" fill="#f2f2f2" rx="7" />
   <rect x="28" y="104" width="58" height="28" fill="#333333" stroke="#bbbbbb" rx="4" />
@@ -33,7 +33,7 @@
   <text x="123" y="124" text-anchor="middle" fill="#888888" font-size="11" font-family="'Segoe UI', Arial, sans-serif">EDIT</text>
   <rect x="160" y="104" width="70" height="28" fill="#f0f0f0" stroke="#bbbbbb" rx="4" />
   <text x="195" y="124" text-anchor="middle" fill="#888888" font-size="11" font-family="'Segoe UI', Arial, sans-serif">DELETE</text>
-  <text x="670" y="123" text-anchor="end" class="label">Total: 3</text>
+  <text x="670" y="123" text-anchor="end" class="label">Total: 4</text>
   <line x1="20" y1="140" x2="680" y2="140" stroke="#d0d0d0" stroke-width="1" />
   <rect x="21" y="140" width="658" height="32" fill="#f8f8f8" />
   <text x="72" y="162" class="label">Display Name</text>
@@ -67,4 +67,12 @@
   <rect x="34" y="259" width="16" height="16" fill="#ffffff" stroke="#cccccc" rx="3" />
   <text x="72" y="274" class="value">Client Secret</text>
   <text x="292" y="274" class="value">Secret</text>
+  <rect x="21" y="286" width="658" height="38" fill="#f7f7f7" />
+  <line x1="20" y1="324" x2="680" y2="324" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="64" y1="286" x2="64" y2="324" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="284" y1="286" x2="284" y2="324" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="444" y1="286" x2="444" y2="324" stroke="#e8e8e8" stroke-width="1" />
+  <rect x="34" y="297" width="16" height="16" fill="#ffffff" stroke="#cccccc" rx="3" />
+  <text x="72" y="312" class="value">Contract ID</text>
+  <text x="292" y="312" class="value">String</text>
 </svg>

--- a/docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId-validation-options.svg
+++ b/docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId-validation-options.svg
@@ -53,10 +53,10 @@
   <circle cx="288" cy="303" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
   <text x="300" y="307" class="label">Hidden</text>
   <text x="20" y="343" class="label">On Device Key Generation</text>
-  <circle cx="28" cy="364" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
+  <circle cx="28" cy="364" r="7" fill="#e8eeff" stroke="#3355ee" stroke-width="1.5" />
+  <circle cx="28" cy="364" r="4" fill="#3355ee" />
   <text x="40" y="368" class="label">Optional</text>
-  <circle cx="158" cy="364" r="7" fill="#e8eeff" stroke="#3355ee" stroke-width="1.5" />
-  <circle cx="158" cy="364" r="4" fill="#3355ee" />
+  <circle cx="158" cy="364" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
   <text x="170" y="368" class="label">Required</text>
   <circle cx="288" cy="364" r="7" fill="#ffffff" stroke="#999999" stroke-width="1" />
   <text x="300" y="368" class="label">Hidden</text>

--- a/docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId.svg
+++ b/docsource/images/Akamai-entry-parameters-store-type-dialog-ContractId.svg
@@ -28,14 +28,14 @@
   <text x="30" y="138" class="value">ContractId</text>
   <text x="20" y="173" class="label">Display Name</text>
   <rect x="20" y="176" width="660" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
-  <text x="30" y="201" class="value">Contract ID</text>
+  <text x="30" y="201" class="value">Contract ID Override</text>
   <text x="20" y="236" class="label">Type</text>
   <rect x="20" y="239" width="660" height="36" fill="#e8e8e8" stroke="#cccccc" rx="4" />
   <text x="30" y="264" class="value">String</text>
   <text x="666" y="265" font-size="12" fill="#666666" font-family="'Segoe UI', Arial, sans-serif">∨</text>
   <text x="20" y="299" class="label">Default Value</text>
   <rect x="20" y="302" width="660" height="36" fill="#ffffff" stroke="#cccccc" rx="4" />
-  <text x="30" y="327" class="value">SET-DEFAULT</text>
+  <text x="30" y="327" class="value"></text>
   <text x="20" y="362" class="label">Multiple Choice Options</text>
   <rect x="20" y="365" width="660" height="36" fill="#e0e0e0" stroke="#cccccc" rx="4" />
   <text x="30" y="390" class="value"></text>

--- a/docsource/images/Akamai-entry-parameters-store-type-dialog.svg
+++ b/docsource/images/Akamai-entry-parameters-store-type-dialog.svg
@@ -57,9 +57,8 @@
   <line x1="284" y1="210" x2="284" y2="248" stroke="#e8e8e8" stroke-width="1" />
   <line x1="444" y1="210" x2="444" y2="248" stroke="#e8e8e8" stroke-width="1" />
   <rect x="34" y="221" width="16" height="16" fill="#ffffff" stroke="#cccccc" rx="3" />
-  <text x="72" y="236" class="value">Contract ID</text>
+  <text x="72" y="236" class="value">Contract ID Override</text>
   <text x="292" y="236" class="value">String</text>
-  <text x="452" y="236" class="value">SET-DEFAULT</text>
   <rect x="21" y="248" width="658" height="38" fill="#ffffff" />
   <line x1="20" y1="286" x2="680" y2="286" stroke="#e8e8e8" stroke-width="1" />
   <line x1="64" y1="248" x2="64" y2="286" stroke="#e8e8e8" stroke-width="1" />

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -74,6 +74,16 @@
               "Required": true,
               "IsPAMEligible": false,
               "Description": "The Akamai client_secret for authentication."
+            },
+            {
+              "Name": "ContractId",
+              "DisplayName": "Contract ID",
+              "Type": "String",
+              "DependsOn": "",
+              "DefaultValue": "",
+              "Required": false,
+              "IsPAMEligible": false,
+              "Description": "The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence."
             }
           ],
           "EntryParameters": [
@@ -91,16 +101,15 @@
             },
             {
               "Name": "ContractId",
-              "DisplayName": "Contract ID",
+              "DisplayName": "Contract ID Override",
               "Type": "String",
               "RequiredWhen": {
                 "HasPrivateKey": false,
                 "OnAdd": false,
                 "OnRemove": false,
-                "OnReenrollment": true
+                "OnReenrollment": false
               },
-              "DefaultValue": "SET-DEFAULT",
-              "Description": "The Contract ID of your account in Akamai."
+              "Description": "The Contract ID of your account in Akamai. If a Contract ID is defined on the certificate store, the value of this parameter will take precedence. If a Contract ID is not defined on the certificate store, a value is required for this parameter."
             },
             {
               "Name": "Sans",

--- a/scripts/migrations/v2.1.0.sql
+++ b/scripts/migrations/v2.1.0.sql
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 Keyfactor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+
+Akamai CPS Orchestrator v2.1.0 Migration Script
+===============================================
+
+This script automates the Akamai certificate store type updates to reflect changes in the v2.1.0
+integration release. This script does the following:
+- Adds a new certificate store property for Contract ID
+- Updates the existing Contract ID entry parameter with the following changes:
+  1. Changes the Display Name from "Contract ID" to "Contract ID Override"
+  2. Removes the DefaultValue from the entry parameter
+  3. Updates the validation behavior of the entry parameter to convert it from Required to Optional
+
+NOTE: The script requires that the Contract ID entry parameter must exist before it is run. Please ensure you have successfully created
+the certificate store completely prior to running this script.
+
+This script can be safely run multiple times. The DryRun parameter controls whether the script changes
+will be committed to the database. You can preview the changes made by this script before committing them.
+
+This script has been designed to work for Keyfactor Command 25+. We cannot guarantee this script will work against future versions of 
+Keyfactor Command. Use at your own discretion.
+*/
+
+----------------------- BEGIN Input variables	---------------------------
+-- The ShortName of the Certificate Store in Keyfactor Command. By default, this should have been populated with Akamai. Modify this field
+-- if the ShortName was set to another value
+DECLARE @StoreTypeShortName NVARCHAR(64) = 'Akamai';
+
+-- If DryRun = 1, then the script changes will NOT be committed to the database. (Useful for checking if the script works before actually making any changes.)
+-- If DryRun = 0, then the script changes WILL BE committed to the database. You'll want to use this value if you're ready to run the script against your database.
+DECLARE @DryRun BIT = 1;
+-- DECLARE @DryRun BIT = 0;
+----------------------- END Input variables	---------------------------
+
+DECLARE @StoreTypeId AS INT;
+DECLARE @ContractIdStoreTypePropertyId AS INT;
+DECLARE @ContractIdEntryParameterId AS INT;
+
+DECLARE @ContractIdEntryParameterDisplayName NVARCHAR(256);
+DECLARE @ContractIdEntryParameterDefaultValue NVARCHAR(100);
+DECLARE @ContractIdEntryParameterValidationOptions NVARCHAR(MAX);
+
+PRINT 'Looking up certificate store type ' + @StoreTypeShortName + ' in Keyfactor Command database...';
+
+SELECT @StoreTypeId = [StoreType] from [cms_agents].[CertStoreTypes] where [ShortName] = @StoreTypeShortName;
+
+IF @StoreTypeId IS NULL
+BEGIN
+    PRINT ''
+	PRINT '******** ERROR	***********************'
+	PRINT 'ERROR: StoreTypeId is NULL. Was the correct ShortName provided? If you have not already, create the Akamai store type before running this script.'
+	RETURN;
+END
+
+BEGIN TRY
+
+    PRINT 'Certificate store type ID: ' + CONVERT(NVARCHAR, @StoreTypeId)
+
+    SELECT @ContractIdStoreTypePropertyId = [Id] FROM [cms_agents].[CertStoreTypeProperties] WHERE [StoreTypeId] = @StoreTypeId AND [Name] = 'ContractId';
+    SELECT @ContractIdEntryParameterId = [Id], @ContractIdEntryParameterDisplayName = [DisplayName], @ContractIdEntryParameterDefaultValue = [DefaultValue], @ContractIdEntryParameterValidationOptions = [ValidationOptions]  FROM [cms_agents].[CertStoreTypeEntryParameters] WHERE [StoreTypeId] = @StoreTypeId AND [Name] = 'ContractId';
+
+    IF @ContractIdEntryParameterId IS NULL
+    BEGIN
+        -- It is expected that the Contract ID is already a defined entry parameter on the certificate store. If this is not the case, then we do not want to recreate
+        -- this parameter in this script. Encourage the end user to create the certificate store properly before running this script.
+        PRINT ''
+    	PRINT '******** ERROR	***********************'
+    	PRINT 'ERROR: Contract ID Entry Parameter is NULL. The entry parameter was expected to already exist on the certificate store. Please create the Akamai store type before running this script (using kfutil, the jobproperties.sql script, or creating it manually).'
+    	RETURN;
+    END
+
+    -- We are now ready to start modifying SQL data
+    BEGIN TRANSACTION
+
+    IF @ContractIdStoreTypePropertyId IS NULL
+    BEGIN
+        PRINT 'Creating store type property for Contract ID...';
+
+        INSERT INTO [cms_agents].[CertStoreTypeProperties]
+        ([StoreTypeId], [Name], [DisplayName], [Type], [DependsOn], [DefaultValue], [ValidationOptions])
+        VALUES
+        (@StoreTypeId, 'ContractId', 'Contract ID', 0, NULL, NULL, '{"OnCreation":0}');
+
+        PRINT 'Store type property for Contract ID has been successfully created.';
+    END
+
+    IF @ContractIdEntryParameterDisplayName = 'Contract ID'
+    BEGIN
+        PRINT 'Updating Contract ID Display Name to Contract ID Override...';
+
+        UPDATE [cms_agents].[CertStoreTypeEntryParameters]
+        SET [DisplayName] = 'Contract ID Override'
+        WHERE [Id] = @ContractIdEntryParameterId;
+
+        PRINT 'Updated Contract ID Display Name to Contract ID Override.';
+    END
+
+    IF @ContractIdEntryParameterDefaultValue IS NOT NULL
+    BEGIN
+        PRINT 'Updating Contract ID Entry Parameter to set the Default Value to NULL...';
+
+        UPDATE [cms_agents].[CertStoreTypeEntryParameters]
+        SET [DefaultValue] = NULL
+        WHERE [Id] = @ContractIdEntryParameterId;
+
+        PRINT 'Updated Contract ID Entry Parameter to be NULL.';
+    END
+
+    IF JSON_VALUE(@ContractIdEntryParameterValidationOptions, '$.OnODKG') = '1'
+    BEGIN
+        PRINT 'Updating Contract ID Entry Parameter ValidationOptions to make OnODKG optional...';
+    
+        UPDATE [cms_agents].[CertStoreTypeEntryParameters]
+        SET [ValidationOptions] = JSON_MODIFY([ValidationOptions], '$.OnODKG', 0)
+        WHERE [Id] = @ContractIdEntryParameterId;
+    
+        PRINT 'Updated Contract ID Entry Parameter ValidationOptions.';
+    END
+    
+    -- CertStoreTypeProperties changes (preview)
+    SELECT
+    *
+    FROM [cms_agents].[CertStoreTypeProperties]
+    WHERE [StoreTypeId] = @StoreTypeId
+    AND [Name] = 'ContractId';
+    
+    -- CertStoreTypeEntryParameters (preview)
+    SELECT
+    *
+    FROM [cms_agents].[CertStoreTypeEntryParameters] 
+    WHERE [StoreTypeId] = @StoreTypeId
+    AND [Name] = 'ContractId';
+    
+
+
+    IF @DryRun = 1
+    BEGIN
+    	PRINT 'INFO: This is a dry run of the script. Rolling back any changes made...'
+    	ROLLBACK TRANSACTION
+    	PRINT 'Rollback successful.'
+    END
+    ELSE
+    BEGIN
+    	PRINT 'Committing changes to the database...'
+    	COMMIT TRANSACTION
+    	PRINT 'Changes committed successfully.'
+    END
+
+
+    PRINT ''
+    PRINT 'The script has finished successfully.'
+
+END TRY
+BEGIN CATCH
+    -- If there is an active transaction, roll it back
+	IF XACT_STATE() <> 0
+    BEGIN
+        PRINT 'Active transaction found. Rolling back.'
+	    ROLLBACK TRANSACTION;
+    END
+
+    PRINT ''
+    PRINT '************** AN UNEXPECTED ERORR OCCURRED *****************************'
+    PRINT 'Error number: ' + CAST(ERROR_NUMBER() AS NVARCHAR);
+    PRINT 'Message: ' + ERROR_MESSAGE();
+END CATCH

--- a/scripts/store_types/bash/curl_create_store_types.sh
+++ b/scripts/store_types/bash/curl_create_store_types.sh
@@ -56,6 +56,16 @@ curl -s -X POST "https://${KEYFACTOR_HOSTNAME}/${KEYFACTOR_API_PATH}/Certificate
       "Required": true,
       "IsPAMEligible": false,
       "Description": "The Akamai client_secret for authentication."
+    },
+    {
+      "Name": "ContractId",
+      "DisplayName": "Contract ID",
+      "Type": "String",
+      "DependsOn": "",
+      "DefaultValue": "",
+      "Required": false,
+      "IsPAMEligible": false,
+      "Description": "The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence."
     }
   ],
   "EntryParameters": [
@@ -73,16 +83,15 @@ curl -s -X POST "https://${KEYFACTOR_HOSTNAME}/${KEYFACTOR_API_PATH}/Certificate
     },
     {
       "Name": "ContractId",
-      "DisplayName": "Contract ID",
+      "DisplayName": "Contract ID Override",
       "Type": "String",
       "RequiredWhen": {
         "HasPrivateKey": false,
         "OnAdd": false,
         "OnRemove": false,
-        "OnReenrollment": true
+        "OnReenrollment": false
       },
-      "DefaultValue": "SET-DEFAULT",
-      "Description": "The Contract ID of your account in Akamai."
+      "Description": "The Contract ID of your account in Akamai. If a Contract ID is defined on the certificate store, the value of this parameter will take precedence. If a Contract ID is not defined on the certificate store, a value is required for this parameter."
     },
     {
       "Name": "Sans",

--- a/scripts/store_types/powershell/restmethod_create_store_types.ps1
+++ b/scripts/store_types/powershell/restmethod_create_store_types.ps1
@@ -56,6 +56,16 @@ $Body = @'
       "Required": true,
       "IsPAMEligible": false,
       "Description": "The Akamai client_secret for authentication."
+    },
+    {
+      "Name": "ContractId",
+      "DisplayName": "Contract ID",
+      "Type": "String",
+      "DependsOn": "",
+      "DefaultValue": "",
+      "Required": false,
+      "IsPAMEligible": false,
+      "Description": "The default Akamai Contract ID for the certificate store. When performing re-enrollment, the Contract ID entry parameter will take precedence."
     }
   ],
   "EntryParameters": [
@@ -73,16 +83,15 @@ $Body = @'
     },
     {
       "Name": "ContractId",
-      "DisplayName": "Contract ID",
+      "DisplayName": "Contract ID Override",
       "Type": "String",
       "RequiredWhen": {
         "HasPrivateKey": false,
         "OnAdd": false,
         "OnRemove": false,
-        "OnReenrollment": true
+        "OnReenrollment": false
       },
-      "DefaultValue": "SET-DEFAULT",
-      "Description": "The Contract ID of your account in Akamai."
+      "Description": "The Contract ID of your account in Akamai. If a Contract ID is defined on the certificate store, the value of this parameter will take precedence. If a Contract ID is not defined on the certificate store, a value is required for this parameter."
     },
     {
       "Name": "Sans",


### PR DESCRIPTION
# 2.1.0
## Features
- Add a default Contract ID to the certificate store type, allowing for a per-store default with an override provided via the entry parameter. The existing Contract ID entry parameter has been renamed to Contract ID Override and has been made optional. This update is backwards compatible with older versions of the certificate store type.
